### PR TITLE
Make healthcheck headers configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,15 @@ resource "kubernetes_deployment" "deployment" {
               path = var.healthcheck_path
               port = 80
 
+              dynamic "httpHeaders" {
+                for_each = var.healthcheck_headers
+                iterator = header
+                content {
+                  name  = header.value["name"]
+                  value = header.value["value"]
+                }
+              }
+
             }
             period_seconds        = 10
             initial_delay_seconds = 15

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,19 @@ EOT
   type        = string
 }
 
+variable "healthcheck_headers" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+  description = <<EOT
+HTTP headers to be set on healthcheck requests.
+See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes
+for documentation, including the default headers.
+EOT
+}
+
 variable "env_vars" {
   type = list(object({
     name  = string


### PR DESCRIPTION
This should support making healthchecks work when HTTPS redirection is used, such as by https://github.com/scimma/scimma-admin/pull/47 .